### PR TITLE
Support for earlier Python releases

### DIFF
--- a/djchoices/choices.py
+++ b/djchoices/choices.py
@@ -1,5 +1,5 @@
 import re
-from collections import OrderedDict
+from django.utils.datastructures import SortedDict as OrderedDict
 
 __all__ = ["ChoiceItem", "DjangoChoices", "C"]
 


### PR DESCRIPTION
Currently, django-choices uses the `OrderedDict` type, which AFAIK is only available from Python 2.7 onwards. As many (production) environments still use 2.6 or earlier releases, it would make a lot of sense not to use this newer data structure (for now) - or at least use some kind of compatibility wrapper.

My current approach is to use Django's `SortedDict` type, but I have not tested it properly (`setup.py test` finds no problems though). Should give some feedback on whether or not this works pretty soon - but feel free to test beforehand.
