### PR TITLE
Fix issue #25 and move to Tox for unit testing different build matrices

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,3 +6,6 @@ source = djchoices
 omit = */tests/*
 exclude_lines =
     pragma: no cover
+
+[html]
+directory = cover

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 *.pyc
 .project
 .pydevproject
+.tox
 
 # coverage
 htmlcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,45 +1,41 @@
 language: python
 sudo: false
 
-python:
-  - "2.6"
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "pypy"
-
-env:
-  - DJANGO_VERSION=1.3.7
-  - DJANGO_VERSION=1.4.22
-  - DJANGO_VERSION=1.5.12
-  - DJANGO_VERSION=1.6.11
-  - DJANGO_VERSION=1.7.10
-  - DJANGO_VERSION=1.8.4
-
-matrix:
-  exclude:
-    - python: "2.6"
-      env: DJANGO_VERSION=1.7.10
-    - python: "2.6"
-      env: DJANGO_VERSION=1.8.4
-    - python: "3.3"
-      env: DJANGO_VERSION=1.3.7
-    - python: "3.3"
-      env: DJANGO_VERSION=1.4.22
-    - python: "3.4"
-      env: DJANGO_VERSION=1.3.7
-    - python: "3.4"
-      env: DJANGO_VERSION=1.4.22
-
-# command to install dependencies
 install:
-  - "pip install -q Django==$DJANGO_VERSION --use-mirrors"
-  - "if [[ $DJANGO_VERSION < 1.5 ]]; then pip install -q six --use-mirrors; fi"
-  - "if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install -q unittest2; fi"
-  - "pip install coverage coveralls"
-
-# command to run tests
-script: coverage run runtests.py
-
+  - pip install coverage coveralls tox
+script:
+  - tox
 after_success:
   - coveralls
+
+env:
+  - TOXENV=py26-django13
+  - TOXENV=py26-django14
+  - TOXENV=py26-django15
+  - TOXENV=py26-django16
+
+  - TOXENV=py27-django13
+  - TOXENV=py27-django14
+  - TOXENV=py27-django15
+  - TOXENV=py27-django16
+  - TOXENV=py27-django17
+  - TOXENV=py27-django18
+  - TOXENV=py27-djangolatest
+
+  - TOXENV=py33-django15
+  - TOXENV=py33-django16
+  - TOXENV=py33-django17
+  - TOXENV=py33-django18
+  - TOXENV=py33-djangolatest
+
+  - TOXENV=py34-django15
+  - TOXENV=py34-django16
+  - TOXENV=py34-django17
+  - TOXENV=py34-django18
+  - TOXENV=py34-djangolatest
+
+  - TOXENV=pypy-django15
+  - TOXENV=pypy-django16
+  - TOXENV=pypy-django17
+  - TOXENV=pypy-django18
+  - TOXENV=pypy-djangolatest

--- a/djchoices/__init__.py
+++ b/djchoices/__init__.py
@@ -1,5 +1,7 @@
+from pkg_resources import get_distribution
+
 from djchoices.choices import ChoiceItem, DjangoChoices, C
 
-__version__ = '1.4.1'
+__version__ = get_distribution('django-choices').version
 
 __all__ = ["ChoiceItem", "DjangoChoices", "C"]

--- a/runtests.py
+++ b/runtests.py
@@ -7,7 +7,7 @@ from os import path
 from sys import stdout
 
 
-if __name__ == "__main__":
+def get_suite():
     disc_folder = path.abspath(path.dirname(__file__))
 
     stdout.write("Discovering tests in '%s'..." % disc_folder)
@@ -15,8 +15,16 @@ if __name__ == "__main__":
     loader = unittest.loader.defaultTestLoader
     suite.addTest(loader.discover(disc_folder, pattern="test*.py"))
     stdout.write("Done.\n")
+    return suite
 
+
+def run_tests():
+    suite = get_suite()
     stdout.write("Running tests...\n")
     runner = unittest.TextTestRunner()
     runner.verbosity = 2
     runner.run(suite.run)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,17 @@
 from os import path
 from setuptools import setup, find_packages
 
-try:
-    from django.utils import six
-except ImportError:
-    REQUIRE_SIX = True
-else:
-    REQUIRE_SIX = False
-
-from djchoices import __version__
 
 with open(path.join(path.dirname(__file__), 'README.rst')) as f:
     readme = f.read()
 
 setup(
     name="django-choices",
-    version=__version__,
+    version='1.4.2',
     license="MIT",
     description="Sanity for the django choices functionality.",
     long_description=readme,
-    install_requires=['Django>=1.3'] + (['six'] if REQUIRE_SIX else []),
+    install_requires=['Django>=1.3', 'six'],
     test_suite='runtests.get_suite',
     url="https://github.com/bigjason/django-choices",
     author="Jason Webb",

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     description="Sanity for the django choices functionality.",
     long_description=readme,
     install_requires=['Django>=1.3'] + (['six'] if REQUIRE_SIX else []),
+    test_suite='runtests.get_suite',
     url="https://github.com/bigjason/django-choices",
     author="Jason Webb",
     author_email="bigjasonwebb@gmail.com",

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+envlist = py{26,27}-django{13,14,15,16},py27-django{17,18,latest},py{33,34,py}-django{15,16,17,18,latest}
+skip_missing_interpreters = true
+
+[testenv]
+deps=
+  django13: Django>=1.3,<1.4
+  django14: Django>=1.4,<1.5
+  django15: Django>=1.5,<1.6
+  django16: Django>=1.6,<1.7
+  django17: Django>=1.7,<1.8
+  django18: Django>=1.8,<1.9
+  py26: unittest2
+  django13,django14: six
+  coverage
+  coveralls
+commands=coverage run --rcfile={toxinidir}/.coveragerc {toxinidir}/setup.py test


### PR DESCRIPTION
Makes sure that the package can be installed again without having to install Django manually first.

The testing stack moves to tox to better manage different python/django versions.

`six` is now always a dependency, and not only on Django 1.3/1.4. The reason is that on new installs the django import fails anyway as it's a dependency, so six will be installed either way. It's a single file, so I guess the overhead will be neglible.