### PR TITLE
Nullboolean support

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,3 +10,4 @@ Many thanks to the various contributors:
 * https://github.com/soulne4ny
 * https://github.com/vaad2
 * https://github.com/WoLpH
+* https://github.com/ashwch

--- a/djchoices/choices.py
+++ b/djchoices/choices.py
@@ -33,6 +33,8 @@ class StaticProp(object):
 
 # End Support Functionality
 
+sentinel = object()
+
 
 class ChoiceItem(object):
     """
@@ -44,7 +46,7 @@ class ChoiceItem(object):
     """
     order = 0
 
-    def __init__(self, value=None, label=None, order=None):
+    def __init__(self, value=sentinel, label=None, order=None):
         self.value = value
         self.label = label
 
@@ -93,7 +95,7 @@ class DjangoChoicesMeta(type):
                     # TODO: mark translatable by default?
                     label = cls.name_clean.sub(" ", field_name)
 
-                val0 = label if val.value is None else val.value
+                val0 = label if val.value is sentinel else val.value
                 choices.append((val0, label))
                 attrs[field_name] = StaticProp(val0)
                 setattr(labels, field_name, label)

--- a/djchoices/tests/test_choices.py
+++ b/djchoices/tests/test_choices.py
@@ -37,6 +37,11 @@ class EmptyValueClass(DjangoChoices):
     Option2 = ChoiceItem()
     Option3 = ChoiceItem()
 
+class NullBooleanValueClass(DjangoChoices):
+    Option1 = ChoiceItem(None, "Pending")
+    Option2 = ChoiceItem(True, "Successful")
+    Option3 = ChoiceItem(False, "Failed")
+
 
 class DjangoChoices(unittest.TestCase):
     def setUp(self):
@@ -164,6 +169,15 @@ class DjangoChoices(unittest.TestCase):
         self.assertEqual(choices[0][0], "Option1")
         self.assertEqual(choices[1][0], "Option2")
         self.assertEqual(choices[2][0], "Option3")
+
+    def test_null_boolean_value_class(self):
+        choices = NullBooleanValueClass.choices
+        self.assertEqual(choices[0][0], None)
+        self.assertEqual(choices[1][0], True)
+        self.assertEqual(choices[2][0], False)
+        self.assertEqual(choices[0][1], "Pending")
+        self.assertEqual(choices[1][1], "Successful")
+        self.assertEqual(choices[2][1], "Failed")
 
     @unittest.skipUnless(*has_new_migrations())
     def test_deconstructible_validator(self):


### PR DESCRIPTION
This PR adds support for [`NullBooleanField`](https://docs.djangoproject.com/en/dev/ref/models/fields/#django.db.models.NullBooleanField).