### PR TITLE
Update Djano and Python versions in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,8 +31,8 @@ Requirements
 ------------
 
 Django choices is fairly simple, so most Python and Django
-versions should work. It is tested against Python 2.7, 3.3, 3.4, 3.5 and PyPy.
-Django 1.8 until and including 1.11 alpha are supported (and tested in Travis).
+versions should work. It is tested against Python 2.7, 3.4, 3.5, 3.6, 3.7 and PyPy.
+Django 1.11 until and including 2.22 are supported (and tested in Travis).
 
 If you need to support older Python or Django versions, you should stick with
 version ``1.4.4``. Backwards compatibility is dropped from 1.5 onwards.


### PR DESCRIPTION
The Python and Django versions were out of sync in the docs.  (It almost put me off using it as I assumed it was just an old package).