### PR TITLE
Adding django3 testing in tox matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,17 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 
 env:
   - DJANGO=1.11
   - DJANGO=2.0
   - DJANGO=2.1
   - DJANGO=2.2
+  - DJANGO=3.0
+  - DJANGO=3.1
+  - DJANGO=3.2
 
 matrix:
   fast_finish: true
@@ -20,9 +25,15 @@ matrix:
     - { python: "2.7", env: DJANGO=2.0 }
     - { python: "2.7", env: DJANGO=2.1 }
     - { python: "2.7", env: DJANGO=2.2 }
+    - { python: "2.7", env: DJANGO=3.0 }
+    - { python: "2.7", env: DJANGO=3.1 }
+    - { python: "2.7", env: DJANGO=3.2 }
 
     - { python: "3.4", env: DJANGO=2.1 }
     - { python: "3.4", env: DJANGO=2.2 }
+    - { python: "3.4", env: DJANGO=3.0 }
+    - { python: "3.4", env: DJANGO=3.1 }
+    - { python: "3.4", env: DJANGO=3.2 }
 
 install:
   - pip install coverage coveralls tox tox-travis

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,9 @@ DJANGO =
   2.0: django20
   2.1: django21
   2.2: django22
+  3.0: django30
+  3.1: django31
+  3.2: django32
 
 [testenv]
 deps=
@@ -20,6 +23,9 @@ deps=
   django20: Django>=2.0,<2.1
   django21: Django>=2.1,<2.2
   django22: Django>=2.2,<3.0
+  django30: Django>=3.0,<3.1
+  django31: Django>=3.1,<3.2
+  django32: Django>=3.2,<3.3
   coverage
   coveralls
 commands=coverage run --rcfile={toxinidir}/.coveragerc {toxinidir}/setup.py test


### PR DESCRIPTION
Using this package extensively. So it would be helpful if new version release with django3.2 support.

Tests are not running.
**Since June 15th, 2021, the building on travis-ci.org is ceased. Please use travis-ci.com from now on.**